### PR TITLE
Fix a potential buffer overflow in the Log function.

### DIFF
--- a/YSFReflector/Log.cpp
+++ b/YSFReflector/Log.cpp
@@ -149,7 +149,7 @@ void Log(unsigned int level, const char* fmt, ...)
 {
 	assert(fmt != NULL);
 
-	char buffer[501U];
+	char buffer[540U];
 #if defined(_WIN32) || defined(_WIN64)
 	SYSTEMTIME st;
 	::GetSystemTime(&st);


### PR DESCRIPTION
Make sure there is enough room in the log buffer.

This is a pull request in reference to Issue #8 